### PR TITLE
Bug fix (formatter="ISO_DATE_TIME")

### DIFF
--- a/src/main/java/com/github/javaplugs/jsf/DateTimeConverter.java
+++ b/src/main/java/com/github/javaplugs/jsf/DateTimeConverter.java
@@ -54,11 +54,11 @@ public abstract class DateTimeConverter extends javax.faces.convert.DateTimeConv
         this.formatter = DateTimeFormatter.ofPattern(pattern);
     }
 
-    public DateTimeFormatter getFormatter() {
+    protected DateTimeFormatter getFormatter() {
         return this.formatter;
     }
 
-    public void setFormatter(DateTimeFormatter formatter) {
+    protected void setFormatter(DateTimeFormatter formatter) {
         this.formatter = formatter;
     }
 
@@ -136,7 +136,7 @@ public abstract class DateTimeConverter extends javax.faces.convert.DateTimeConv
                 try {
                     return (String) method.invoke(component);
                 } catch (IllegalAccessException | InvocationTargetException e) {
-                    throw new RuntimeException(e.getMessage(), e);
+                    return null;
                 }
             }
         }


### PR DESCRIPTION
Fix of problem: "Cannot convert ISO_DATE_TIME of type class java.lang.String to class java.time.format.DateTimeFormatter" and a little improvement (getPatternFromUiComponent shouldn't affect on execution, if it fails).